### PR TITLE
Update sbt native image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .lib/
 target/
 .idea
+.bsp

--- a/build.sbt
+++ b/build.sbt
@@ -7,13 +7,11 @@ enablePlugins(NativeImagePlugin)
 nativeImageReady := { () =>
   ()
 }
+nativeImageVersion := "22.3.1"
 nativeImageOptions ++= Seq(
-  "--allow-incomplete-classpath",
   "--no-fallback",
-  "--initialize-at-build-time",
   "--enable-http",
-  "--enable-https",
-  "--enable-all-security-services",
+  "--enable-https"
   // "--static" not supported on mac
 )
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.3.13
+sbt.version=1.10.2

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,3 @@
-addSbtPlugin("org.scalameta" % "sbt-native-image" % "0.2.1")
+addSbtPlugin("org.scalameta" % "sbt-native-image" % "0.3.4")
 addSbtPlugin("com.eed3si9n"  % "sbt-assembly"     % "0.15.0")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt"     % "2.4.2")


### PR DESCRIPTION
Updates

- sbt version
- sbt-native-image
- graalVmImage to one that works on Mac
- remove deprecated flags from latest graalVm version